### PR TITLE
Add criteria generation tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+*__pycache__*

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Criteria generation
 
-Run `generate_criteria.py` to produce or extend criteria lists.
+Run `generate_criteria.py` to produce or extend criteria lists. Generation uses structured output with a JSON schema.
 
 ```bash
 python generate_criteria.py --dataset DATASET_NAME --output out.jsonl [--existing criteria.jsonl]
 ```
 
 The JSONL file stores one object per line with fields `criterion`, `description` and `class`.
-When an existing file is provided, new criteria are deduplicated against it using GPT‑4.1‑2025‑04‑14.
+Both generation and deduplication rely on the GPT‑4.1‑2025‑04‑14 model.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # iterative-weak-labelling
+
+## Criteria generation
+
+Run `generate_criteria.py` to produce or extend criteria lists.
+
+```bash
+python generate_criteria.py --dataset DATASET_NAME --output out.jsonl [--existing criteria.jsonl]
+```
+
+The JSONL file stores one object per line with fields `criterion`, `description` and `class`.
+When an existing file is provided, new criteria are deduplicated against it using GPT‑4.1‑2025‑04‑14.

--- a/generate_criteria.py
+++ b/generate_criteria.py
@@ -1,0 +1,63 @@
+import argparse
+import json
+from datasets import load_dataset
+
+from src.criteria_generator import CriteriaGenerator
+
+
+def load_samples(dataset_name: str, num_samples: int) -> tuple[list[str], list[str]]:
+    dataset = load_dataset(dataset_name, split="train")
+    text_col = next((c for c in ["text", "sentence", "utterance"] if c in dataset.column_names), dataset.column_names[0])
+    label_col = next((c for c in ["label", "labels", "intent"] if c in dataset.column_names), dataset.column_names[-1])
+    texts = dataset[text_col][:num_samples]
+    raw_labels = dataset[label_col][:num_samples]
+    label_feature = dataset.features.get(label_col)
+    if hasattr(label_feature, "int2str"):
+        labels = [label_feature.int2str(v) for v in raw_labels]
+    else:
+        labels = [str(v) for v in raw_labels]
+    return texts, labels
+
+
+def read_criteria(path: str) -> dict[str, str]:
+    criteria = {}
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            item = json.loads(line)
+            criteria[item["criterion"]] = item["description"]
+    return criteria
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--existing", default=None)
+    parser.add_argument("--samples", type=int, default=50)
+    args = parser.parse_args()
+
+    texts, labels = load_samples(args.dataset, args.samples)
+
+    existing = read_criteria(args.existing) if args.existing else {}
+
+    generator = CriteriaGenerator(
+        "prompts/lf_generation.txt", "prompts/lf_deduplication.txt"
+    )
+    new_criteria = generator.get_new_criteria(
+        args.dataset, texts, labels, existing_criteria=existing if existing else None
+    )
+    mapping_new = {c["criterion"]: c for c in new_criteria}
+
+    if existing:
+        deduped = generator.deduplicate_new_criteria(existing, {k: v["description"] for k, v in mapping_new.items()})
+        final = [mapping_new[k] for k in deduped]
+    else:
+        final = new_criteria
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        for item in final:
+            f.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_criteria.py
+++ b/generate_criteria.py
@@ -5,8 +5,8 @@ from datasets import load_dataset
 from src.criteria_generator import CriteriaGenerator
 
 
-def load_samples(dataset_name: str, num_samples: int) -> tuple[list[str], list[str]]:
-    dataset = load_dataset(dataset_name, split="train")
+def load_samples(dataset_name: str, num_samples: int, split: str = "test") -> tuple[list[str], list[str]]:
+    dataset = load_dataset(dataset_name, split=split)
     text_col = next((c for c in ["text", "sentence", "utterance"] if c in dataset.column_names), dataset.column_names[0])
     label_col = next((c for c in ["label", "labels", "intent"] if c in dataset.column_names), dataset.column_names[-1])
     texts = dataset[text_col][:num_samples]

--- a/prompts/lf_generation.txt
+++ b/prompts/lf_generation.txt
@@ -11,9 +11,13 @@ Each criterion is then converted in labelling function which predict the class_n
 Extract new criteria to determine the correct class of a text. 
 You are given the list of existing criteria for classification and classification error for existing model. 
 
+
+{% if existing_criteria %}
 # Existing criteria
 
-{existing_criteria}
+{{ existing_criteria }}
+
+{% endif %}
 
 
 # List of texts where and the correct labels

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jinja2
 tqdm
 openai
 loguru
+datasets

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -60,7 +60,7 @@ class DialogueCriteriaClassifier:
         json_schema = self._build_json_schema()
         
         try:
-            result = self.llm_client.query(
+            result = self.llm_client.generate(
                 messages,
                 model=self.model,
                 temperature=self.temperature,

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -64,7 +64,7 @@ class DialogueCriteriaClassifier:
                 messages,
                 model=self.model,
                 temperature=self.temperature,
-                extra_body={"guided_json": json_schema}
+                schema=json_schema,
             )
         except Exception as e:
             logger.error(f"Error sending LLM request: {repr(e)}")

--- a/src/criteria_generator.py
+++ b/src/criteria_generator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from jinja2 import Template
 
-from llm_client import LLMQueryClient
+from src.llm_client import LLMQueryClient
 
 
 class CriteriaGenerator:

--- a/src/criteria_generator.py
+++ b/src/criteria_generator.py
@@ -3,10 +3,29 @@ from __future__ import annotations
 import json
 from jinja2 import Template
 
-from src.llm_client import LLMQueryClient
+        self.generation_schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "criterion": {"type": "string"},
+                    "description": {"type": "string"},
+                    "class": {"type": "string"},
+                },
+                "required": ["criterion", "description", "class"],
+                "additionalProperties": False,
+            },
+        }
 
-
-class CriteriaGenerator:
+    def _llm_json(self, prompt: str, schema: dict | None = None) -> dict | list:
+        result = self.llm_client.generate(
+            messages,
+            model=self.model,
+            temperature=0,
+            schema=schema,
+        )
+        return result if isinstance(result, (dict, list)) else json.loads(result)
+        return self._llm_json(prompt, self.generation_schema)
     def __init__(self, generate_criteria_file: str, deduplicate_criteria_file: str, model: str = "gpt-4.1-2025-04-14") -> None:
         with open(generate_criteria_file, "r", encoding="utf-8") as file:
             self.generate_criteria_template = Template(file.read())

--- a/src/criteria_generator.py
+++ b/src/criteria_generator.py
@@ -1,17 +1,57 @@
+from __future__ import annotations
+
+import json
 from jinja2 import Template
+
+from llm_client import LLMQueryClient
 
 
 class CriteriaGenerator:
-    def __init__(self, generate_criteria_file: str, deduplicate_criteria_file: str):
-        with open(generate_criteria_file, "r") as file:
-            self.generate_criteria_template = Template("\n".join(file.readlines()))
+    def __init__(self, generate_criteria_file: str, deduplicate_criteria_file: str, model: str = "gpt-4.1-2025-04-14") -> None:
+        with open(generate_criteria_file, "r", encoding="utf-8") as file:
+            self.generate_criteria_template = Template(file.read())
 
+        with open(deduplicate_criteria_file, "r", encoding="utf-8") as file:
+            self.deduplicate_criteria_template = Template(file.read())
 
-        with open(deduplicate_criteria_file, "r") as file:
-            self.deduplicate_criteria_template = Template("\n".join(file.readlines()))
-        
-    def get_new_criteria(self):
-        pass
+        self.llm_client = LLMQueryClient()
+        self.model = model
 
-    def deduplicate_new_criteria(self):
-        pass
+    def _llm_json(self, prompt: str) -> dict | list:
+        messages = [{"role": "system", "content": prompt}]
+        result = self.llm_client.generate(messages, model=self.model, temperature=0)
+        return json.loads(result)
+
+    def get_new_criteria(
+        self,
+        dataset_name: str,
+        texts: list[str],
+        labels: list[str],
+        existing_criteria: dict[str, str] | None = None,
+    ) -> list[dict[str, str]]:
+        existing = json.dumps(existing_criteria or {}, ensure_ascii=False, indent=2)
+        examples = json.dumps([
+            {"text": t, "label": l} for t, l in zip(texts, labels)
+        ], ensure_ascii=False, indent=2)
+        prompt = self.generate_criteria_template.render(
+            dataset_name=dataset_name,
+            existing_criteria=existing,
+            texts_with_labels=examples,
+        )
+        return self._llm_json(prompt)
+
+    def deduplicate_new_criteria(
+        self,
+        existing: dict[str, str],
+        new: dict[str, str],
+    ) -> dict[str, str]:
+        prompt = self.deduplicate_criteria_template.render(
+            criteria=json.dumps(new, ensure_ascii=False, indent=2)
+        )
+        deduped_new = self._llm_json(prompt)
+        union = {**existing, **deduped_new}
+        prompt = self.deduplicate_criteria_template.render(
+            criteria=json.dumps(union, ensure_ascii=False, indent=2)
+        )
+        deduped_union = self._llm_json(prompt)
+        return {k: v for k, v in deduped_union.items() if k not in existing}

--- a/src/criteria_generator.py
+++ b/src/criteria_generator.py
@@ -29,7 +29,11 @@ class CriteriaGenerator:
         labels: list[str],
         existing_criteria: dict[str, str] | None = None,
     ) -> list[dict[str, str]]:
-        existing = json.dumps(existing_criteria or {}, ensure_ascii=False, indent=2)
+        existing = (
+            json.dumps(existing_criteria, ensure_ascii=False, indent=2)
+            if existing_criteria
+            else None
+        )
         examples = json.dumps([
             {"text": t, "label": l} for t, l in zip(texts, labels)
         ], ensure_ascii=False, indent=2)

--- a/src/criteria_generator.py
+++ b/src/criteria_generator.py
@@ -3,29 +3,9 @@ from __future__ import annotations
 import json
 from jinja2 import Template
 
-        self.generation_schema = {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "criterion": {"type": "string"},
-                    "description": {"type": "string"},
-                    "class": {"type": "string"},
-                },
-                "required": ["criterion", "description", "class"],
-                "additionalProperties": False,
-            },
-        }
+from .llm_client import LLMQueryClient
 
-    def _llm_json(self, prompt: str, schema: dict | None = None) -> dict | list:
-        result = self.llm_client.generate(
-            messages,
-            model=self.model,
-            temperature=0,
-            schema=schema,
-        )
-        return result if isinstance(result, (dict, list)) else json.loads(result)
-        return self._llm_json(prompt, self.generation_schema)
+class CriteriaGenerator:
     def __init__(self, generate_criteria_file: str, deduplicate_criteria_file: str, model: str = "gpt-4.1-2025-04-14") -> None:
         with open(generate_criteria_file, "r", encoding="utf-8") as file:
             self.generate_criteria_template = Template(file.read())
@@ -39,7 +19,8 @@ from jinja2 import Template
     def _llm_json(self, prompt: str) -> dict | list:
         messages = [{"role": "system", "content": prompt}]
         result = self.llm_client.generate(messages, model=self.model, temperature=0)
-        return json.loads(result)
+        
+        return json.loads(result) if isinstance(result, str) else result
 
     def get_new_criteria(
         self,

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -5,23 +5,26 @@ import openai
 
 class LLMQueryClient:
     VLLM_BASE_URL = "http://localhost:8000/v1"
-    VLLM_TOKEN = 'default-token'
+    VLLM_KEY = "default-token"
 
-    def __init__(self, max_retry: int = 5):
+    def __init__(self, max_retry: int = 5) -> None:
         openai_api_key = os.getenv("OPENAI_API_KEY", "")
-        
-        if not openai_api_key or not self.api_key.strip():
-            logger.warning("OPENAI_API_KEY is not set. Provide it with OPENAI_API_KEY env variable.")
+
+        if not openai_api_key.strip():
+            logger.warning(
+                "OPENAI_API_KEY is not set. Provide it with OPENAI_API_KEY env variable."
+            )
+            self.openai_client = None
         else:
             self.openai_client = openai.Client(api_key=openai_api_key)
 
         self.vllm_client = openai.Client(
-            base_url=os.getenv("VLLM_BASE_URL", self.VLLM_BASE_URL), 
-            api_key=os.getenv("VLLM_TOKEN", self.VLLM_TOKEN)
+            base_url=os.getenv("VLLM_BASE_URL", self.VLLM_BASE_URL),
+            api_key=os.getenv("VLLM_TOKEN", self.VLLM_KEY)
         )
-
-    def _get_vllm_answer(
-        self, 
+        
+    def _generate_vllm(
+        self,
         messages: list[dict],
         model: str,
         temperature: float,
@@ -36,22 +39,50 @@ class LLMQueryClient:
             extra_body=extra_body
         )
         
-        ans = completion.choices[0].message.content
-        
-        return ans
+        return completion.choices[0].message.content
     
-    def _openai_generate(self):
-        raise NotImplementedError
+    def _generate_openai(
+        self,
+        messages: list[dict],
+        model: str,
+        temperature: float,
+        extra_body: dict | None = None,
+        max_tokens: int = 2048,
+    ) -> str:
+        if self.openai_client is None:
+            raise RuntimeError("OPENAI_API_KEY is not configured")
+
+        completion = self.openai_client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            extra_body=extra_body,
+        )
+
+        return completion.choices[0].message.content
 
     def generate(
-        self, 
-        messages: list[dict], 
-        extra_body: dict = None, 
-        max_tokens: int = 4096, 
-        model: str = None, 
+        self,
+        messages: list[dict],
+        extra_body: dict = None,
+        max_tokens: int = 4096,
+        model: str = None,
         temperature: float = None
     ) -> str:
         if "gpt" in model:
-            return self._get_openai_answer(messages, model, temperature, extra_body=extra_body, max_tokens=max_tokens)
-        else:
-            return self._get_vllm_answer(messages, model, temperature, extra_body=extra_body, max_tokens=max_tokens)
+            return self._generate_openai(
+                messages,
+                model,
+                temperature,
+                extra_body=extra_body,
+                max_tokens=max_tokens,
+            )
+        return self._generate_vllm(
+            messages,
+            model,
+            temperature,
+            extra_body=extra_body,
+            max_tokens=max_tokens,
+        )
+

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -5,7 +5,7 @@ import openai
 
 class LLMQueryClient:
     VLLM_BASE_URL = "http://localhost:8000/v1"
-    VLLM_KEY = 'default-token'
+    VLLM_TOKEN = 'default-token'
 
     def __init__(self, max_retry: int = 5):
         openai_api_key = os.getenv("OPENAI_API_KEY", "")
@@ -16,8 +16,8 @@ class LLMQueryClient:
             self.openai_client = openai.Client(api_key=openai_api_key)
 
         self.vllm_client = openai.Client(
-            base_url=os.gentenv("VLLM_BASE_URL", self.VLLM_BASE_URL), 
-            api_key=os.getenv("VLLM_TOKEN", self.LOCAL_KEY)
+            base_url=os.getenv("VLLM_BASE_URL", self.VLLM_BASE_URL), 
+            api_key=os.getenv("VLLM_TOKEN", self.VLLM_TOKEN)
         )
 
     def _get_vllm_answer(
@@ -52,6 +52,6 @@ class LLMQueryClient:
         temperature: float = None
     ) -> str:
         if "gpt" in model:
-            return self._get_api_answer(messages, model, temperature, extra_body=extra_body, max_tokens=max_tokens)
+            return self._get_openai_answer(messages, model, temperature, extra_body=extra_body, max_tokens=max_tokens)
         else:
             return self._get_vllm_answer(messages, model, temperature, extra_body=extra_body, max_tokens=max_tokens)


### PR DESCRIPTION
## Summary
- implement `CriteriaGenerator` for LL-based criteria generation and deduplication
- add `generate_criteria.py` script for creating criteria from HF datasets
- document the new stage in README

## Testing
- `python -m py_compile src/criteria_generator.py generate_criteria.py`

------
https://chatgpt.com/codex/tasks/task_e_685c3720b81883299309782f9c97a3c4