### PR TITLE
Add criteria generation schema and logging

### DIFF
--- a/prompts/lf_deduplication.txt
+++ b/prompts/lf_deduplication.txt
@@ -2,7 +2,7 @@
 
 You will be given a dictionary of criteria and their descriptions.
 Remove duplicates — criteria that describe the same thing.
-In your response, I want to receive a dictionary that includes only unique (non-overlapping) criteria from the original dictionary.
+In your response, I want to receive a list of criterion that includes only unique (non-overlapping) criteria from the original dictionary.
 If all criteria in the original dictionary are different, simply copy it into the response.
 
 # Dictionary of criteria
@@ -11,12 +11,20 @@ If all criteria in the original dictionary are different, simply copy it into th
 
 # Response format
 
-Reply in JSON format with the following structure:
+Reply in JSON format with the following json schema:
 
 ```json
 {
-    "criterion_name_1": str,
-    "criterion_name_2": str,
-    ...
+  "type": "object",
+  "properties": {
+    "unique_criteria": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["unique_criteria"],
+  "additionalProperties": false
 }
 ```

--- a/prompts/lf_generation.txt
+++ b/prompts/lf_generation.txt
@@ -1,43 +1,57 @@
-# Context
+{# Context #}
 
-I am solving text classification task for {dataset_name} dataset via Weak Supervision. 
-I have a labelling functions formulated in a form of binary criterion (value — True/False). 
-The value for a given text and criterion is collected via few-shot-prompting LLM.
-Each criteria corresponds to specific class.
-Each criterion is then converted in labelling function which predict the class_name if True else ABSTAIN. 
+I am solving a text classification task for the **{{ dataset_name }}** dataset using Weak Supervision.  
+I have formulated labeling functions based on binary criteria (value — True/False).  
+The value for a given text and criterion is obtained via few-shot prompting of a language model (LLM).  
+Each criterion corresponds to a specific class.  
+Each criterion is then converted into a labeling function that predicts the class name if True, or ABSTAIN otherwise.  
 
-# Task
+{# Task #}
 
-Extract new criteria to determine the correct class of a text. 
-You are given the list of existing criteria for classification and classification error for existing model. 
-
+Your task is to extract new criteria that help determine the correct class of a text.  
+You are provided with a list of existing criteria and classification errors from the current model.  
 
 {% if existing_criteria %}
-# Existing criteria
+### Existing Criteria
 
 {{ existing_criteria }}
-
 {% endif %}
 
+### List of texts and their correct labels
 
-# List of texts where and the correct labels
+{{ texts_with_labels }}
 
-{texts_with_labels}
+### Response Format
 
+List all new criteria in the response. For each, include:
 
-# Response format
+- `criterion`: a short name for the criterion  
+- `description`: a detailed explanation that can guide an LLM to identify matching texts  
+- `class`: the class to which the criterion applies  
 
-List all new criteria in the response. For each, include the name, a description of the criterion, and the class to which it belongs.
-The description should be clear for LLM and consist of several sentences and explain the dialogues that match this criterion.
+The description should consist of several sentences and explain the types of dialogues that match this criterion.
 
-Respond in JSON format with the following structure:
+Respond in **JSON** format using the following json schema:
 
 ```json
 {
-    "criteria": [
-        {"criterion": str, "description": str, "class": str},
-        {"criterion": str, "description": str, "class": str},
-        ...
-    ]
+    "type": "object",
+    "properties": {
+        "criteria": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "criterion": {"type": "string"},
+                    "description": {"type": "string"},
+                    "class": {"type": "string"},
+                },
+                "required": ["criterion", "description", "class"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["criteria"],
+    "additionalProperties": False,
 }
 ```

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -38,7 +38,7 @@ class LLMQueryClient:
                 "json_schema": {
                     "name": "response",
                     "schema": schema,
-                    "strict": True,
+                    "strict": False,
                 },
             }
         else:


### PR DESCRIPTION
## Summary
- support JSON schema-based output in `CriteriaGenerator`
- adjust `generate_criteria.py` to parse the schema output and log progress

## Testing
- `python -m py_compile generate_criteria.py src/criteria_generator.py src/llm_client.py src/classifier.py`
- `pip install -q -r requirements.txt` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_685c45ec9db483299602abb9a6919a2c